### PR TITLE
Fewer string allocations

### DIFF
--- a/src/tz_linux.rs
+++ b/src/tz_linux.rs
@@ -1,11 +1,7 @@
 pub(crate) fn get_timezone_inner() -> Result<String, crate::GetTimezoneError> {
     // see https://stackoverflow.com/a/12523283
-    use std::io::Read;
-
-    let fname = "/etc/timezone";
-    let mut f = std::fs::File::open(&fname)?;
-    let mut contents = String::with_capacity(32);
-    f.read_to_string(&mut contents)?;
+    let mut contents = std::fs::read_to_string("/etc/timezone")?;
+    // Trim to the correct length without allocating.
     contents.truncate(contents.trim_end().len());
     Ok(contents)
 }

--- a/src/tz_linux.rs
+++ b/src/tz_linux.rs
@@ -4,7 +4,8 @@ pub(crate) fn get_timezone_inner() -> Result<String, crate::GetTimezoneError> {
 
     let fname = "/etc/timezone";
     let mut f = std::fs::File::open(&fname)?;
-    let mut contents = String::new();
+    let mut contents = String::with_capacity(32);
     f.read_to_string(&mut contents)?;
-    Ok(contents.trim().to_string())
+    contents.truncate(contents.trim_end().len());
+    Ok(contents)
 }


### PR DESCRIPTION
The longest time zone name has 25 characters. Using `String::with_capacity()` it is possible have fewer re-allocations, and possible systems calls.