### PR TITLE
Implement for {Free,Net,Open}BSD and Dragonfly

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -76,6 +76,39 @@ jobs:
       - run: which wasm-pack || cargo install wasm-pack
       - run: wasm-pack test --node
 
+  build-cross:
+    strategy:
+      matrix:
+        target: [x86_64-unknown-freebsd, x86_64-unknown-netbsd]
+    runs-on: ubuntu-latest
+    name: "Build for ${{ matrix.target }}"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Rust
+        id: actions-rs
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          target: ${{ matrix.target }}
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ matrix.target }}-${{ steps.actions-rs.outputs.rustc_hash }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-${{ steps.actions-rs.outputs.rustc_hash }}-
+            ${{ runner.os }}-${{ matrix.target }}-
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ~/.cargo/bin/
+            target/
+      - run: which cross || cargo install cross
+      - run: cross build --target ${{ matrix.target }} --examples
+
   check:
     strategy:
       matrix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.33"
+version = "0.1.34"
 dependencies = [
  "core-foundation",
  "js-sys",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,16 @@ mod tz_wasm32;
 #[cfg(target_arch = "wasm32")]
 use tz_wasm32 as platform;
 
+#[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+mod tz_freebsd;
+#[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+use tz_freebsd as platform;
+
+#[cfg(any(target_os = "netbsd", target_os = "openbsd"))]
+mod tz_netbsd;
+#[cfg(any(target_os = "netbsd", target_os = "openbsd"))]
+use tz_netbsd as platform;
+
 /// Error types
 #[derive(Debug)]
 pub enum GetTimezoneError {

--- a/src/tz_freebsd.rs
+++ b/src/tz_freebsd.rs
@@ -1,0 +1,7 @@
+pub(crate) fn get_timezone_inner() -> Result<String, crate::GetTimezoneError> {
+    // see https://gitlab.gnome.org/GNOME/evolution-data-server/-/issues/19
+    let mut contents = std::fs::read_to_string("/var/db/zoneinfo")?;
+    // Trim to the correct length without allocating.
+    contents.truncate(contents.trim_end().len());
+    Ok(contents)
+}

--- a/src/tz_netbsd.rs
+++ b/src/tz_netbsd.rs
@@ -1,0 +1,18 @@
+use std::fs::read_link;
+
+const PREFIX: &str = "/usr/share/zoneinfo/";
+
+pub(crate) fn get_timezone_inner() -> Result<String, crate::GetTimezoneError> {
+    // see https://www.cyberciti.biz/faq/openbsd-time-zone-howto/
+    let mut s = read_link("/etc/localtime")?
+        .into_os_string()
+        .into_string()
+        .map_err(|_| crate::GetTimezoneError::FailedParsingString)?;
+    if !s.starts_with(PREFIX) {
+        return Err(crate::GetTimezoneError::FailedParsingString);
+    }
+
+    // Trim to the correct length without allocating.
+    s.replace_range(..PREFIX.len(), "");
+    Ok(s)
+}


### PR DESCRIPTION
Tested successfully on FreeBSD and NetBSD. Dragonfly should work the same as FreeBSD, and OpenBSD as NetBSD.

There are no Github action runners for either of these four BSDs, so the examples get cross compiled, but not executed.