### PR TITLE
Fail to compile for WASI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     strategy:
       matrix:
-        runs-on: [ubuntu-20.04, windows-2019, macos-10.15]
+        runs-on: [ubuntu-20.04, windows-2022, macos-12]
         toolchain: ["1.38", stable, nightly]
     runs-on: ${{ matrix.runs-on }}
     name: "Test (${{ matrix.runs-on }}/${{ matrix.toolchain }})"
@@ -166,7 +166,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - run: cargo doc --all-features
+      - run: RUSTDOCFLAGS="-D warnings" cargo doc --all-features
 
   audit:
     name: "Cargo audit"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "core-foundation",
  "js-sys",
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
 
 [[package]]
 name = "wasm-bindgen"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,35 +18,22 @@
 //! let tz: chrono_tz::Tz = tz_str.parse()?;
 //! ```
 
-#[cfg(target_os = "linux")]
-mod tz_linux;
-#[cfg(target_os = "linux")]
-use tz_linux as platform;
-
-#[cfg(target_os = "windows")]
-mod tz_windows;
-#[cfg(target_os = "windows")]
-use tz_windows as platform;
-
-#[cfg(target_os = "macos")]
-mod tz_macos;
-#[cfg(target_os = "macos")]
-use tz_macos as platform;
-
-#[cfg(target_arch = "wasm32")]
-mod tz_wasm32;
-#[cfg(target_arch = "wasm32")]
-use tz_wasm32 as platform;
-
-#[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
-mod tz_freebsd;
-#[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
-use tz_freebsd as platform;
-
-#[cfg(any(target_os = "netbsd", target_os = "openbsd"))]
-mod tz_netbsd;
-#[cfg(any(target_os = "netbsd", target_os = "openbsd"))]
-use tz_netbsd as platform;
+#[cfg_attr(target_os = "linux", path = "tz_linux.rs")]
+#[cfg_attr(target_os = "windows", path = "tz_windows.rs")]
+#[cfg_attr(target_os = "macos", path = "tz_macos.rs")]
+#[cfg_attr(
+    all(target_arch = "wasm32", not(target_os = "wasi")),
+    path = "tz_wasm32.rs"
+)]
+#[cfg_attr(
+    any(target_os = "freebsd", target_os = "dragonfly"),
+    path = "tz_freebsd.rs"
+)]
+#[cfg_attr(
+    any(target_os = "netbsd", target_os = "openbsd"),
+    path = "tz_netbsd.rs"
+)]
+mod platform;
 
 /// Error types
 #[derive(Debug)]

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,0 +1,8 @@
+pub fn get_timezone_inner() -> std::result::Result<String, crate::GetTimezoneError> {
+    Err(crate::GetTimezoneError::FailedParsingString)
+}
+
+compile_error!(
+    "iana-time-zone is currently implemented for Linux, Window, MacOS, FreeBSD, NetBSD, \
+    OpenBSD, Dragonfly, and WebAssembly (browser).",
+);


### PR DESCRIPTION
PR #38 did not properly separate WebAssembly for the use in a
browser/nodejs, or standalone run in e.g. wasmtime. This PR make the
compilation fail if the target-os is WASI.

Also I deduplicated the imports by using `#[cfg_attr(…, path = …)]`
instead of importing and aliassing in two steps.