### PR TITLE
Fix implementation for Redhat based distros

### DIFF
--- a/src/tz_linux.rs
+++ b/src/tz_linux.rs
@@ -1,7 +1,31 @@
+use std::fs::{read_link, read_to_string};
+
 pub(crate) fn get_timezone_inner() -> Result<String, crate::GetTimezoneError> {
+    etc_localtime().or_else(|_| etc_timezone())
+}
+
+fn etc_timezone() -> Result<String, crate::GetTimezoneError> {
     // see https://stackoverflow.com/a/12523283
-    let mut contents = std::fs::read_to_string("/etc/timezone")?;
+    let mut contents = read_to_string("/etc/timezone")?;
     // Trim to the correct length without allocating.
     contents.truncate(contents.trim_end().len());
     Ok(contents)
+}
+
+fn etc_localtime() -> Result<String, crate::GetTimezoneError> {
+    // https://www.man7.org/linux/man-pages/man5/localtime.5.html
+    // https://www.cyberciti.biz/faq/openbsd-time-zone-howto/
+    const PREFIX: &str = "/usr/share/zoneinfo/";
+
+    let mut s = read_link("/etc/localtime")?
+        .into_os_string()
+        .into_string()
+        .map_err(|_| crate::GetTimezoneError::FailedParsingString)?;
+    if !s.starts_with(PREFIX) {
+        return Err(crate::GetTimezoneError::FailedParsingString);
+    }
+
+    // Trim to the correct length without allocating.
+    s.replace_range(..PREFIX.len(), "");
+    Ok(s)
 }


### PR DESCRIPTION
According to <https://unix.stackexchange.com/a/451714/7851> systemd's
`timedatectl` does not always update `/etc/timezone`, and it uses
`/etc/localtime` instead. So most likely `/etc/localtime` should
overrule `/etc/timezone` on systemd based distros, which is most of
them.

This PR makes the Linux implementation first try to parse
`/etc/localtime`, and if that fails `/etc/timezone`.

This actually makes the implementation a lot faster. The old
implementation that only checked `/etc/timezone` runs in

```text
$ time target/release/examples/stress-test

real	0m0,910s
user	0m0,630s
sys	0m7,909s
```

and the new implementation runs in

```text
$ time target/release/examples/stress-test

real	0m0,197s
user	0m0,345s
sys	0m1,453s
```

on a f2fs formatted root partition. The speed advantage might be less or
not be present at all with other file system.

Closes  #47.