### PR TITLE
Use core-foundation-sys instead of core-foundation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ fallback = []
 android_system_properties = "0.1.4"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-core-foundation = "0.9"
+core-foundation-sys = "0.8.3"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.9", features = ["activation", "combaseapi", "objbase", "roapi", "winerror", "winstring"] }

--- a/src/tz_macos.rs
+++ b/src/tz_macos.rs
@@ -1,5 +1,41 @@
+use core_foundation_sys::base::{CFRelease, CFTypeRef};
+use core_foundation_sys::string::{kCFStringEncodingUTF8, CFStringGetCStringPtr};
+use core_foundation_sys::timezone::{CFTimeZoneCopySystem, CFTimeZoneGetName};
+
 pub(crate) fn get_timezone_inner() -> Result<String, crate::GetTimezoneError> {
-    Ok(core_foundation::timezone::CFTimeZone::system()
-        .name()
-        .to_string())
+    unsafe {
+        Dropping::new(CFTimeZoneCopySystem())
+            .and_then(|tz| Dropping::new(CFTimeZoneGetName(tz.0)))
+            .and_then(|name| {
+                let name = CFStringGetCStringPtr(name.0, kCFStringEncodingUTF8);
+                if name.is_null() {
+                    None
+                } else {
+                    Some(name)
+                }
+            })
+            .and_then(|name| std::ffi::CStr::from_ptr(name).to_str().ok())
+            .map(|name| name.to_owned())
+            .ok_or(crate::GetTimezoneError::OsError)
+    }
+}
+
+struct Dropping<T>(*const T);
+
+impl<T> Drop for Dropping<T> {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe { CFRelease(self.0 as CFTypeRef) };
+    }
+}
+
+impl<T> Dropping<T> {
+    #[inline]
+    unsafe fn new(v: *const T) -> Option<Self> {
+        if v.is_null() {
+            None
+        } else {
+            Some(Self(v))
+        }
+    }
 }


### PR DESCRIPTION
iana-time-zone is used by [chrono], and chrono is (optionally) used by [core-foundation]. So if iana-time-zone uses core-foundation, this results in a circular dependency.

This PR replaces core-foundation by [core-foundation-sys], which breaks the circular dependency.

[chrono]: https://crates.io/crates/chrono
[core-foundation]: https://crates.io/crates/core-foundation
[core-foundation-sys]: https://crates.io/crates/core-foundation-sys