### PR TITLE
Implement for Solaris

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -87,6 +87,7 @@ jobs:
           - i686-linux-android
           - arm-linux-androideabi
           - aarch64-linux-android
+          - sparcv9-sun-solaris
     runs-on: ubuntu-latest
     name: "Build for ${{ matrix.target }}"
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.46] - 2022-08-18
+### Added
+- Implement for Solaris ([#55](https://github.com/strawlab/iana-time-zone/pull/55))
+
 ## [0.1.45] - 2022-08-16
 ### Fixed
 - Fix potential use after free in MacOS / iOS ([#54](https://github.com/strawlab/iana-time-zone/pull/54), [RUSTSEC-2022-0049](https://rustsec.org/advisories/RUSTSEC-2022-0049.html))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iana-time-zone"
 description = "get the IANA time zone for the current system"
-version = "0.1.45"
+version = "0.1.46"
 authors = ["Andrew Straw <strawman@astraw.com>"]
 repository = "https://github.com/strawlab/iana-time-zone"
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,10 @@
     any(target_os = "netbsd", target_os = "openbsd"),
     path = "tz_netbsd.rs"
 )]
-#[cfg_attr(target_os = "illumos", path = "tz_illumos.rs")]
+#[cfg_attr(
+    any(target_os = "illumos", target_os = "solaris"),
+    path = "tz_illumos.rs"
+)]
 #[cfg_attr(target_os = "android", path = "tz_android.rs")]
 mod platform;
 

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -5,5 +5,5 @@ pub fn get_timezone_inner() -> std::result::Result<String, crate::GetTimezoneErr
 #[cfg(not(feature = "fallback"))]
 compile_error!(
     "iana-time-zone is currently implemented for Linux, Window, MacOS, FreeBSD, NetBSD, \
-    OpenBSD, Dragonfly, WebAssembly (browser), iOS, Illumos and Android.",
+    OpenBSD, Dragonfly, WebAssembly (browser), iOS, Illumos, Android, and Solaris.",
 );

--- a/src/tz_illumos.rs
+++ b/src/tz_illumos.rs
@@ -3,6 +3,8 @@ use std::io::{BufRead, BufReader};
 
 pub(crate) fn get_timezone_inner() -> Result<String, crate::GetTimezoneError> {
     // https://illumos.org/man/5/TIMEZONE
+    // https://docs.oracle.com/cd/E23824_01/html/821-1473/uc-timezone-4.html
+
     let file = OpenOptions::new().read(true).open("/etc/default/init")?;
     let mut reader = BufReader::with_capacity(1536, file);
     let mut line = String::with_capacity(80);


### PR DESCRIPTION
Untested, because `x86_64-sun-solaris` is an alias for
`x86_64-unknown-illumos` by now, and there is no docker image for
`x86_64-pc-solaris`.