### PR TITLE
Update to android_system_properties v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.47] - 2022-08-30
+### Changed
+- Update `android_system_properties` to v0.1.5 to run 9786% faster (YMMV) ([#56](https://github.com/strawlab/iana-time-zone/pull/56))
+
 ## [0.1.46] - 2022-08-18
 ### Added
 - Implement for Solaris ([#55](https://github.com/strawlab/iana-time-zone/pull/55))
@@ -190,6 +194,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Implement for Linux, Windows, MacOS 
 
+[0.1.47]: https://github.com/strawlab/iana-time-zone/releases/tag/v0.1.47
+[0.1.46]: https://github.com/strawlab/iana-time-zone/releases/tag/v0.1.46
 [0.1.45]: https://github.com/strawlab/iana-time-zone/releases/tag/v0.1.45
 [0.1.44]: https://github.com/strawlab/iana-time-zone/releases/tag/v0.1.44
 [0.1.43]: https://github.com/strawlab/iana-time-zone/releases/tag/v0.1.43

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iana-time-zone"
 description = "get the IANA time zone for the current system"
-version = "0.1.46"
+version = "0.1.47"
 authors = ["Andrew Straw <strawman@astraw.com>"]
 repository = "https://github.com/strawlab/iana-time-zone"
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,8 @@ edition = "2018"
 fallback = []
 
 [target.'cfg(target_os = "android")'.dependencies]
-android_system_properties = "0.1.4"
+android_system_properties = "0.1.5"
+once_cell = "1.13.1"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 core-foundation-sys = "0.8.3"

--- a/src/tz_android.rs
+++ b/src/tz_android.rs
@@ -1,12 +1,16 @@
+use std::ffi::CStr;
+
 use android_system_properties::AndroidSystemProperties;
+use once_cell::sync::OnceCell;
 
 // From https://android.googlesource.com/platform/ndk/+/android-4.2.2_r1.2/docs/system/libc/OVERVIEW.html
 // The system property named 'persist.sys.timezone' contains the name of the current timezone.
 
-const TIMEZONE_PROP_KEY: &str = "persist.sys.timezone";
+static PROPERTIES: OnceCell<AndroidSystemProperties> = OnceCell::new();
 
 pub(crate) fn get_timezone_inner() -> Result<String, crate::GetTimezoneError> {
-    AndroidSystemProperties::new()
-        .get(TIMEZONE_PROP_KEY)
+    PROPERTIES
+        .get_or_init(AndroidSystemProperties::new)
+        .get_from_cstr(unsafe { CStr::from_bytes_with_nul_unchecked(b"persist.sys.timezone\0") })
         .ok_or(crate::GetTimezoneError::OsError)
 }


### PR DESCRIPTION
The new release makes `AndroidSystemProperties` send + sync, so the
initialization can be cached. This makes the stress test execute in

```text
0m00.61s real     0m04.00s user     0m00.02s system
```

Before it was

```text
1m37.25s real     1m06.81s user     0m57.95s system
```

I.e. it's now 9786 % faster. :)