### PR TITLE
Support AIX operating system

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ mod ffi_utils;
     any(target_os = "illumos", target_os = "solaris"),
     path = "tz_illumos.rs"
 )]
+#[cfg_attr(target_os = "aix", path = "tz_aix.rs")]
 #[cfg_attr(target_os = "android", path = "tz_android.rs")]
 #[cfg_attr(target_os = "haiku", path = "tz_haiku.rs")]
 mod platform;

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -5,5 +5,5 @@ pub fn get_timezone_inner() -> std::result::Result<String, crate::GetTimezoneErr
 #[cfg(not(feature = "fallback"))]
 compile_error!(
     "iana-time-zone is currently implemented for Linux, Window, MacOS, FreeBSD, NetBSD, \
-    OpenBSD, Dragonfly, WebAssembly (browser), iOS, Illumos, Android, Solaris and Haiku.",
+    OpenBSD, Dragonfly, WebAssembly (browser), iOS, Illumos, Android, AIX, Solaris and Haiku.",
 );

--- a/src/tz_aix.rs
+++ b/src/tz_aix.rs
@@ -1,0 +1,26 @@
+use std::fs::OpenOptions;
+use std::io::{BufRead, BufReader};
+use std::env;
+
+pub(crate) fn get_timezone_inner() -> Result<String, crate::GetTimezoneError> {
+    env::var("TZ").map_err(|_| crate::GetTimezoneError::OsError)
+}
+
+fn read_environment() -> Result<String, crate::GetTimezoneError> {
+    // https://www.ibm.com/docs/en/aix/7.2?topic=files-environment-file
+
+    let file = OpenOptions::new().read(true).open("/etc/environment")?;
+    let mut reader = BufReader::new(file);
+    let mut line = String::with_capacity(80);
+    loop {
+        line.clear();
+        let count = reader.read_line(&mut line)?;
+        if count == 0 {
+            return Err(crate::GetTimezoneError::FailedParsingString);
+        } else if line.starts_with("TZ=") {
+            line.truncate(line.trim_end().len());
+            line.replace_range(..3, "");
+            return Ok(line);
+        }
+    }
+}


### PR DESCRIPTION
This change makes this crate support detecting timezone on AIX. Since AIX support hasn't been merged yet, this is in draft status.