### PR TITLE
Downgrade requirements for WASM dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ core-foundation-sys = "0.8.3"
 winapi = { version = "0.3.9", features = ["activation", "combaseapi", "objbase", "roapi", "winerror", "winstring"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys = "0.3.58"
-wasm-bindgen = "0.2.81"
+js-sys = "0.3.46"
+wasm-bindgen = "0.2.70"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = "0.3.31"
+wasm-bindgen-test = "0.3"


### PR DESCRIPTION
WebAssembly support was added in #38 targeting the current versions versions of wasm-bindgen and js-sys at the time, which is reasonable. Unfortunately the whoami crate, in trying to support older Rust versions, has reduced the upper version of wasm-bindgen that it supports, see https://github.com/ardaku/whoami/issues/43.

This PR thus reduces the minimum version required for wasm-bindgen. I used `cargo +nightly update -Z minimal-versions` with `cargo build --target wasm32-unknown-unknown` to find the earliest version that compiles. We could theoretically set up checks in CI to verify this on an ongoing basis, but this might be overkill for now.

cc @Kijewski 