### PR TITLE
Don't use once_cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.49] - 2022-09-22
+### Changed
+- `once_cell` dependency is not needed ([#61](https://github.com/strawlab/iana-time-zone/pull/58))
+
 ## [0.1.48] - 2022-09-12
 ### Changed
 - Downgrade requirements for WASM dependencies ([#58](https://github.com/strawlab/iana-time-zone/pull/58))
@@ -199,6 +203,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Implement for Linux, Windows, MacOS 
 
+[0.1.49]: https://github.com/strawlab/iana-time-zone/releases/tag/v0.1.49
 [0.1.48]: https://github.com/strawlab/iana-time-zone/releases/tag/v0.1.48
 [0.1.47]: https://github.com/strawlab/iana-time-zone/releases/tag/v0.1.47
 [0.1.46]: https://github.com/strawlab/iana-time-zone/releases/tag/v0.1.46

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ fallback = []
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_system_properties = "0.1.5"
-once_cell = "1.13.1"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 core-foundation-sys = "0.8.3"

--- a/src/tz_android.rs
+++ b/src/tz_android.rs
@@ -1,16 +1,27 @@
 use std::ffi::CStr;
+use std::sync::Once;
 
 use android_system_properties::AndroidSystemProperties;
-use once_cell::sync::OnceCell;
+
+static INITALIZED: Once = Once::new();
+static mut PROPERTIES: Option<AndroidSystemProperties> = None;
 
 // From https://android.googlesource.com/platform/ndk/+/android-4.2.2_r1.2/docs/system/libc/OVERVIEW.html
 // The system property named 'persist.sys.timezone' contains the name of the current timezone.
-
-static PROPERTIES: OnceCell<AndroidSystemProperties> = OnceCell::new();
+// SAFETY: the key is NUL-terminated and there are no other NULs
+const KEY: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"persist.sys.timezone\0") };
 
 pub(crate) fn get_timezone_inner() -> Result<String, crate::GetTimezoneError> {
-    PROPERTIES
-        .get_or_init(AndroidSystemProperties::new)
-        .get_from_cstr(unsafe { CStr::from_bytes_with_nul_unchecked(b"persist.sys.timezone\0") })
+    INITALIZED.call_once(|| {
+        let properties = AndroidSystemProperties::new();
+        // SAFETY: `INITALIZED` is synchronizing. The variable is only assigned to once.
+        unsafe { PROPERTIES = Some(properties) };
+    });
+
+    // SAFETY: `INITALIZED` is synchronizing. The variable is only assigned to once.
+    let properties = unsafe { PROPERTIES.as_ref() };
+
+    properties
+        .and_then(|properties| properties.get_from_cstr(KEY))
         .ok_or(crate::GetTimezoneError::OsError)
 }


### PR DESCRIPTION
`once_cell` upgraded the MSRV to 1.56. This breaks the use of `iana-time-zone` transitively even though we only use it for Android targets.

This PR replaces `once_cell` by using `static mut` + `std::sync::Once`. `once_cell` is more or less only a safe wrapper around both, but not actually needed. We already do the same in our Windows targets.

Cf. <https://github.com/matklad/once_cell/issues/201>