### PR TITLE
Follow up to #61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.50] - 2022-09-23
+### Fixed
+- Reduce MSRV for Android again
+
 ## [0.1.49] - 2022-09-22
 ### Changed
-- `once_cell` dependency is not needed ([#61](https://github.com/strawlab/iana-time-zone/pull/58))
+- `once_cell` dependency is not needed ([#61](https://github.com/strawlab/iana-time-zone/pull/61))
 
 ## [0.1.48] - 2022-09-12
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.50] - 2022-09-23
 ### Fixed
-- Reduce MSRV for Android again
+- Reduce MSRV for Android again ([#62](https://github.com/strawlab/iana-time-zone/pull/62))
 
 ## [0.1.49] - 2022-09-22
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iana-time-zone"
 description = "get the IANA time zone for the current system"
-version = "0.1.49"
+version = "0.1.50"
 authors = ["Andrew Straw <strawman@astraw.com>"]
 repository = "https://github.com/strawlab/iana-time-zone"
 license = "MIT OR Apache-2.0"

--- a/src/tz_android.rs
+++ b/src/tz_android.rs
@@ -3,15 +3,21 @@ use std::sync::Once;
 
 use android_system_properties::AndroidSystemProperties;
 
-static INITALIZED: Once = Once::new();
-static mut PROPERTIES: Option<AndroidSystemProperties> = None;
-
-// From https://android.googlesource.com/platform/ndk/+/android-4.2.2_r1.2/docs/system/libc/OVERVIEW.html
-// The system property named 'persist.sys.timezone' contains the name of the current timezone.
-// SAFETY: the key is NUL-terminated and there are no other NULs
-const KEY: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"persist.sys.timezone\0") };
-
 pub(crate) fn get_timezone_inner() -> Result<String, crate::GetTimezoneError> {
+    // From https://android.googlesource.com/platform/ndk/+/android-4.2.2_r1.2/docs/system/libc/OVERVIEW.html
+    // The system property named 'persist.sys.timezone' contains the name of the current timezone.
+    // SAFETY: the key is NUL-terminated and there are no other NULs
+    let key = unsafe { CStr::from_bytes_with_nul_unchecked(b"persist.sys.timezone\0") };
+
+    get_properties()
+        .and_then(|properties| properties.get_from_cstr(key))
+        .ok_or(crate::GetTimezoneError::OsError)
+}
+
+fn get_properties() -> Option<&'static AndroidSystemProperties> {
+    static INITALIZED: Once = Once::new();
+    static mut PROPERTIES: Option<AndroidSystemProperties> = None;
+
     INITALIZED.call_once(|| {
         let properties = AndroidSystemProperties::new();
         // SAFETY: `INITALIZED` is synchronizing. The variable is only assigned to once.
@@ -19,9 +25,5 @@ pub(crate) fn get_timezone_inner() -> Result<String, crate::GetTimezoneError> {
     });
 
     // SAFETY: `INITALIZED` is synchronizing. The variable is only assigned to once.
-    let properties = unsafe { PROPERTIES.as_ref() };
-
-    properties
-        .and_then(|properties| properties.get_from_cstr(KEY))
-        .ok_or(crate::GetTimezoneError::OsError)
+    unsafe { PROPERTIES.as_ref() }
 }


### PR DESCRIPTION
* [`CStr::from_bytes_with_nul_unchecked()`] is only `const` since rustc 1.59.0. Just don't use it `const`.
* Moving the `static mut` variable into a getter function makes it more obvious that it cannot be changed after the initial assignment.

[`CStr::from_bytes_with_nul_unchecked()`]: https://doc.rust-lang.org/1.64.0/std/ffi/struct.CStr.html#method.from_bytes_with_nul_unchecked