### PR TITLE
macOS unsafe refactor

### DIFF
--- a/src/tz_macos.rs
+++ b/src/tz_macos.rs
@@ -5,25 +5,25 @@ use core_foundation_sys::string::{
 use core_foundation_sys::timezone::{CFTimeZoneCopySystem, CFTimeZoneGetName};
 
 pub(crate) fn get_timezone_inner() -> Result<String, crate::GetTimezoneError> {
-    unsafe { get_timezone().ok_or(crate::GetTimezoneError::OsError) }
+    get_timezone().ok_or(crate::GetTimezoneError::OsError)
 }
 
 #[inline]
-unsafe fn get_timezone() -> Option<String> {
+fn get_timezone() -> Option<String> {
     // The longest name in the IANA time zone database is 25 ASCII characters long.
     const MAX_LEN: usize = 32;
 
     // Get system time zone, and borrow its name.
-    let tz = Dropping::new(CFTimeZoneCopySystem())?;
-    let name = CFTimeZoneGetName(tz.0);
+    let tz = Dropping::new(unsafe { CFTimeZoneCopySystem() })?;
+    let name = unsafe { CFTimeZoneGetName(tz.0) };
     if name.is_null() {
         return None;
     }
 
     // If the name is encoded in UTF-8, copy it directly.
-    let cstr = CFStringGetCStringPtr(name, kCFStringEncodingUTF8);
+    let cstr = unsafe { CFStringGetCStringPtr(name, kCFStringEncodingUTF8) };
     if !cstr.is_null() {
-        let cstr = std::ffi::CStr::from_ptr(cstr);
+        let cstr = unsafe { std::ffi::CStr::from_ptr(cstr) };
         if let Ok(name) = cstr.to_str() {
             return Some(name.to_owned());
         }
@@ -34,18 +34,20 @@ unsafe fn get_timezone() -> Option<String> {
     let mut buf_bytes = 0;
     let range = CFRange {
         location: 0,
-        length: CFStringGetLength(name),
+        length: unsafe { CFStringGetLength(name) },
     };
-    if CFStringGetBytes(
-        name,
-        range,
-        kCFStringEncodingUTF8,
-        b'\0',
-        false as Boolean,
-        buf.as_mut_ptr(),
-        buf.len() as isize,
-        &mut buf_bytes,
-    ) != range.length
+    if unsafe {
+        CFStringGetBytes(
+            name,
+            range,
+            kCFStringEncodingUTF8,
+            b'\0',
+            false as Boolean,
+            buf.as_mut_ptr(),
+            buf.len() as isize,
+            &mut buf_bytes,
+        )
+    } != range.length
     {
         // Could not convert the name.
         None
@@ -70,7 +72,7 @@ impl<T> Drop for Dropping<T> {
 
 impl<T> Dropping<T> {
     #[inline]
-    unsafe fn new(v: *const T) -> Option<Self> {
+    fn new(v: *const T) -> Option<Self> {
         if v.is_null() {
             None
         } else {


### PR DESCRIPTION
As discussed in #64, especially https://github.com/strawlab/iana-time-zone/issues/64#issuecomment-1258944132, this refactoring to isolate only the specific calls that need to be unsafe.

I also created a new label [Unsafe-Proposed](https://github.com/strawlab/iana-time-zone/labels/Unsafe-Proposed) and assigned this PR with it. (Also as discussed in #64).