### PR TITLE
Refactor Android property key `CStr` construction to add tests

### DIFF
--- a/src/ffi_utils.rs
+++ b/src/ffi_utils.rs
@@ -1,0 +1,49 @@
+//! Cross platform FFI helpers.
+
+use std::ffi::CStr;
+
+// The system property named 'persist.sys.timezone' contains the name of the
+// current timezone.
+//
+// From https://android.googlesource.com/platform/bionic/+/gingerbread-release/libc/docs/OVERVIEW.TXT#79:
+//
+// > The name of the current timezone is taken from the TZ environment variable,
+// > if defined. Otherwise, the system property named 'persist.sys.timezone' is
+// > checked instead.
+const ANDROID_TIMEZONE_PROPERTY_NAME: &[u8] = b"persist.sys.timezone\0";
+
+/// Return a [`CStr`] to access the timezone from an Android system properties
+/// environment.
+pub fn android_timezone_property_name() -> &'static CStr {
+    // In tests or debug mode, opt into extra runtime checks.
+    if cfg!(any(test, debug_assertions)) {
+        return CStr::from_bytes_with_nul(ANDROID_TIMEZONE_PROPERTY_NAME).unwrap();
+    }
+
+    // SAFETY: the key is NUL-terminated and there are no other NULs, this
+    // invariant is checked in tests.
+    unsafe { CStr::from_bytes_with_nul_unchecked(ANDROID_TIMEZONE_PROPERTY_NAME) }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::CStr;
+
+    use super::{android_timezone_property_name, ANDROID_TIMEZONE_PROPERTY_NAME};
+
+    #[test]
+    fn test_android_timezone_property_name_is_valid_cstr() {
+        CStr::from_bytes_with_nul(ANDROID_TIMEZONE_PROPERTY_NAME).unwrap();
+
+        let mut invalid_property_name = ANDROID_TIMEZONE_PROPERTY_NAME.to_owned();
+        invalid_property_name.push(b'\0');
+        CStr::from_bytes_with_nul(&invalid_property_name).unwrap_err();
+    }
+
+    #[test]
+    fn test_android_timezone_property_name_getter() {
+        let key = android_timezone_property_name().to_bytes_with_nul();
+        assert_eq!(key, ANDROID_TIMEZONE_PROPERTY_NAME);
+        std::str::from_utf8(key).unwrap();
+    }
+}

--- a/src/ffi_utils.rs
+++ b/src/ffi_utils.rs
@@ -14,7 +14,7 @@ const ANDROID_TIMEZONE_PROPERTY_NAME: &[u8] = b"persist.sys.timezone\0";
 
 /// Return a [`CStr`] to access the timezone from an Android system properties
 /// environment.
-pub fn android_timezone_property_name() -> &'static CStr {
+pub(crate) fn android_timezone_property_name() -> &'static CStr {
     // In tests or debug mode, opt into extra runtime checks.
     if cfg!(any(test, debug_assertions)) {
         return CStr::from_bytes_with_nul(ANDROID_TIMEZONE_PROPERTY_NAME).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,9 @@
 //! let tz: chrono_tz::Tz = tz_str.parse()?;
 //! ```
 
+#[allow(dead_code)]
+mod ffi_utils;
+
 #[cfg_attr(target_os = "linux", path = "tz_linux.rs")]
 #[cfg_attr(target_os = "windows", path = "tz_windows.rs")]
 #[cfg_attr(any(target_os = "macos", target_os = "ios"), path = "tz_macos.rs")]

--- a/src/tz_android.rs
+++ b/src/tz_android.rs
@@ -3,11 +3,10 @@ use std::sync::Once;
 
 use android_system_properties::AndroidSystemProperties;
 
+use crate::ffi_utils::android_timezone_property_name;
+
 pub(crate) fn get_timezone_inner() -> Result<String, crate::GetTimezoneError> {
-    // From https://android.googlesource.com/platform/ndk/+/android-4.2.2_r1.2/docs/system/libc/OVERVIEW.html
-    // The system property named 'persist.sys.timezone' contains the name of the current timezone.
-    // SAFETY: the key is NUL-terminated and there are no other NULs
-    let key = unsafe { CStr::from_bytes_with_nul_unchecked(b"persist.sys.timezone\0") };
+    let key = android_timezone_property_name();
 
     get_properties()
         .and_then(|properties| properties.get_from_cstr(key))


### PR DESCRIPTION
Add a new FFI utils module that is always tested on all platforms.

Extract the C string bytes to a const and getter function, add more docs, add tests that the const can be safely turned into a `CStr`.