### PR TITLE
bump MSRV to 1.38

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         runs-on: [ubuntu-20.04, windows-2022, macos-12]
         toolchain:
-          - "1.31"
+          - "1.38"
           - stable
           - nightly
         versions:
@@ -53,7 +53,7 @@ jobs:
         include:
           # Without `-Zminimal-versions` a too recent bumpalo version is selected. Newer versions use `edition = "2021"`.
           - versions: "-Zminimal-versions"
-          - toolchain: "1.31"
+          - toolchain: "1.38"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -187,7 +187,7 @@ jobs:
       fail-fast: false
       matrix:
         toolchain:
-          - "1.31"
+          - "1.38"
           - stable
           - nightly
         versions:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cargo run --example get_timezone
 
 ## Minimum supported rust version policy
 
-This crate has a minimum supported rust version (MSRV) of 1.31
+This crate has a minimum supported rust version (MSRV) of 1.38
 for [Tier 1](https://doc.rust-lang.org/1.63.0/rustc/platform-support.html) platforms.
 
 Updates to the MSRV are sometimes necessary due to the MSRV of dependencies. MSRV updates will


### PR DESCRIPTION
This is the MSRV of `chrono` since their 0.4.22 release.

Fixes #68.