### PR TITLE
Get Haiku platform crate compiling on non-Haiku platforms

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -294,10 +294,8 @@ jobs:
         runs-on: [ubuntu-20.04, windows-2022, macos-12]
         toolchain:
           - stable
-          - nightly
         versions:
           - ""
-          - "-Zminimal-versions"
     runs-on: ${{ matrix.runs-on }}
     env:
       RUSTFLAGS: -D warnings
@@ -326,10 +324,8 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - nightly
         versions:
           - ""
-          - "-Zminimal-versions"
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -286,3 +286,71 @@ jobs:
 
       - name: Lint and check formatting with clang-format
         run: npx github:artichoke/clang-format --check
+
+  test-haiku:
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubuntu-20.04, windows-2022, macos-12]
+        toolchain:
+          - stable
+          - nightly
+        versions:
+          - ""
+          - "-Zminimal-versions"
+    runs-on: ${{ matrix.runs-on }}
+    env:
+      RUSTFLAGS: -D warnings
+      RUST_BACKTRACE: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Rust
+        id: actions-rs
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.toolchain }}
+          override: true
+      - name: Update lockfile
+        run: cargo generate-lockfile ${{ matrix.versions }}
+        working-directory: haiku
+        env:
+          RUSTC_BOOTSTRAP: 1
+      - run: cargo test --all-targets
+        working-directory: haiku
+
+  check-haiku:
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain:
+          - stable
+          - nightly
+        versions:
+          - ""
+          - "-Zminimal-versions"
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
+      RUST_BACKTRACE: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Rust
+        id: actions-rs
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.toolchain }}
+          override: true
+          components: clippy
+      - name: Update lockfile
+        run: cargo generate-lockfile ${{ matrix.versions }}
+        working-directory: haiku
+        env:
+          RUSTC_BOOTSTRAP: 1
+      - run: cargo check --all-targets
+        working-directory: haiku
+      - run: cargo clippy --all-targets
+        working-directory: haiku

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ wasm-bindgen = "0.2.70"
 wasm-bindgen-test = "0.3"
 
 [target.'cfg(target_os = "haiku")'.dependencies]
-iana-time-zone-haiku = { version = "0.1.0", path = "haiku" }
+iana-time-zone-haiku = { version = "0.1.1", path = "haiku" }
 
 [workspace]
 members = [".", "haiku"]

--- a/haiku/Cargo.toml
+++ b/haiku/Cargo.toml
@@ -5,6 +5,8 @@ version = "0.1.1"
 authors = ["René Kijewski <crates.io@k6i.de>"]
 repository = "https://github.com/strawlab/iana-time-zone"
 license = "MIT OR Apache-2.0"
+keywords = ["IANA", "time"]
+categories = ["date-and-time", "internationalization", "os"]
 readme = "README.md"
 edition = "2018"
 

--- a/haiku/Cargo.toml
+++ b/haiku/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iana-time-zone-haiku"
 description = "iana-time-zone support crate for Haiku OS"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["René Kijewski <crates.io@k6i.de>"]
 repository = "https://github.com/strawlab/iana-time-zone"
 license = "MIT OR Apache-2.0"

--- a/haiku/build.rs
+++ b/haiku/build.rs
@@ -6,9 +6,9 @@ fn main() {
         .flag_if_supported("-std=c++11")
         .compile("tz_haiku");
 
-    println!("cargo:return-if-changed=src/lib.rs");
-    println!("cargo:return-if-changed=src/implementation.cc");
-    println!("cargo:return-if-changed=src/interface.h");
+    println!("cargo:rerun-if-changed=src/lib.rs");
+    println!("cargo:rerun-if-changed=src/implementation.cc");
+    println!("cargo:rerun-if-changed=src/interface.h");
 
     let target = env::var_os("TARGET").expect("cargo should set TARGET env var");
     let target = target

--- a/haiku/build.rs
+++ b/haiku/build.rs
@@ -1,11 +1,20 @@
+use std::env;
+
 fn main() {
     cxx_build::bridge("src/lib.rs")
         .file("src/implementation.cc")
         .flag_if_supported("-std=c++11")
         .compile("tz_haiku");
 
-    println!("cargo:return-if-changed=include/interface.h");
-    println!("cargo:return-if-changed=src/implementation.cc");
     println!("cargo:return-if-changed=src/lib.rs");
-    println!("cargo:rustc-link-lib=be");
+    println!("cargo:return-if-changed=src/implementation.cc");
+    println!("cargo:return-if-changed=src/interface.h");
+
+    let target = env::var_os("TARGET").expect("cargo should set TARGET env var");
+    let target = target
+        .to_str()
+        .expect("TARGET env var should be valid UTF-8");
+    if target.contains("haiku") {
+        println!("cargo:rustc-link-lib=be");
+    }
 }

--- a/haiku/src/implementation.cc
+++ b/haiku/src/implementation.cc
@@ -1,9 +1,9 @@
 #include "iana-time-zone-haiku/src/interface.h"
 #include "iana-time-zone-haiku/src/lib.rs.h"
 
-#ifdef __HAIKU__
-
 #include <cstring>
+
+#ifdef __HAIKU__
 
 #include <Errors.h>
 #include <LocaleRoster.h>
@@ -57,6 +57,8 @@ size_t ::iana_time_zone_haiku::get_tz(rust::Slice<uint8_t> buf) {
 
 #else
 
-size_t ::iana_time_zone_haiku::get_tz(rust::Slice<uint8_t>) { return 0; }
+namespace iana_time_zone_haiku {
+size_t get_tz(rust::Slice<uint8_t>) { return 0; }
+}  // namespace iana_time_zone_haiku
 
 #endif

--- a/haiku/src/implementation.cc
+++ b/haiku/src/implementation.cc
@@ -1,9 +1,9 @@
 #include "iana-time-zone-haiku/src/interface.h"
 #include "iana-time-zone-haiku/src/lib.rs.h"
 
-#include <cstring>
-
 #ifdef __HAIKU__
+
+#include <cstring>
 
 #include <Errors.h>
 #include <LocaleRoster.h>

--- a/haiku/src/implementation.cc
+++ b/haiku/src/implementation.cc
@@ -10,7 +10,8 @@
 #include <String.h>
 #include <TimeZone.h>
 
-size_t ::iana_time_zone_haiku::get_tz(rust::Slice<uint8_t> buf) {
+namespace iana_time_zone_haiku {
+size_t get_tz(rust::Slice<uint8_t> buf) {
     try {
         static_assert(sizeof(char) == sizeof(uint8_t), "Illegal char size");
 
@@ -54,6 +55,7 @@ size_t ::iana_time_zone_haiku::get_tz(rust::Slice<uint8_t> buf) {
         return 0;
     }
 }
+}  // namespace iana_time_zone_haiku
 
 #else
 

--- a/haiku/src/lib.rs
+++ b/haiku/src/lib.rs
@@ -27,3 +27,12 @@ pub fn get_timezone() -> Option<String> {
         s => Some(std::str::from_utf8(s).ok()?.to_owned()),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    #[cfg(not(target_os = "haiku"))]
+    fn test_fallback_on_non_haiku_platforms() {
+        assert!(super::get_timezone().is_none());
+    }
+}

--- a/haiku/src/lib.rs
+++ b/haiku/src/lib.rs
@@ -30,6 +30,16 @@ mod ffi {
     }
 }
 
+/// Get the current IANA time zone as a string.
+///
+/// On Haiku platforms this function will return [`Some`] with the timezone string
+/// or [`None`] if an error occurs. On all other platforms, [`None`] is returned.
+///
+/// # Examples
+///
+/// ```
+/// let timezone = iana_time_zone_haiku::get_timezone();
+/// ```
 pub fn get_timezone() -> Option<String> {
     // The longest name in the IANA time zone database is 25 ASCII characters long.
     let mut buf = [0u8; 32];

--- a/haiku/src/lib.rs
+++ b/haiku/src/lib.rs
@@ -1,3 +1,16 @@
+#![warn(clippy::all)]
+#![warn(clippy::cargo)]
+#![warn(clippy::undocumented_unsafe_blocks)]
+#![allow(unknown_lints)]
+#![warn(missing_copy_implementations)]
+#![warn(missing_debug_implementations)]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+#![warn(trivial_casts, trivial_numeric_casts)]
+#![warn(unsafe_op_in_unsafe_fn)]
+#![warn(unused_qualifications)]
+#![warn(variant_size_differences)]
+
 /// # iana-time-zone-haiku
 ///
 /// [![Crates.io](https://img.shields.io/crates/v/iana-time-zone-haiku.svg)](https://crates.io/crates/iana-time-zone-haiku)

--- a/haiku/src/lib.rs
+++ b/haiku/src/lib.rs
@@ -11,14 +11,14 @@
 #![warn(unused_qualifications)]
 #![warn(variant_size_differences)]
 
-/// # iana-time-zone-haiku
-///
-/// [![Crates.io](https://img.shields.io/crates/v/iana-time-zone-haiku.svg)](https://crates.io/crates/iana-time-zone-haiku)
-/// [![Documentation](https://docs.rs/iana-time-zone/badge.svg)](https://docs.rs/iana-time-zone/)
-/// [![Crate License](https://img.shields.io/crates/l/iana-time-zone-haiku-haiku.svg)](https://crates.io/crates/iana-time-zone-haiku)
-/// [![build](https://github.com/strawlab/iana-time-zone/workflows/build/badge.svg?branch=master)](https://github.com/strawlab/iana-time-zone/actions?query=branch%3Amaster)
-///
-/// [iana-time-zone](https://github.com/strawlab/iana-time-zone) support crate for Haiku OS.
+//! # iana-time-zone-haiku
+//!
+//! [![Crates.io](https://img.shields.io/crates/v/iana-time-zone-haiku.svg)](https://crates.io/crates/iana-time-zone-haiku)
+//! [![Documentation](https://docs.rs/iana-time-zone/badge.svg)](https://docs.rs/iana-time-zone/)
+//! [![Crate License](https://img.shields.io/crates/l/iana-time-zone-haiku-haiku.svg)](https://crates.io/crates/iana-time-zone-haiku)
+//! [![build](https://github.com/strawlab/iana-time-zone/workflows/build/badge.svg?branch=master)](https://github.com/strawlab/iana-time-zone/actions?query=branch%3Amaster)
+//!
+//! [iana-time-zone](https://github.com/strawlab/iana-time-zone) support crate for Haiku OS.
 
 #[cxx::bridge(namespace = "iana_time_zone_haiku")]
 mod ffi {

--- a/haiku/src/lib.rs
+++ b/haiku/src/lib.rs
@@ -58,4 +58,11 @@ mod tests {
     fn test_fallback_on_non_haiku_platforms() {
         assert!(super::get_timezone().is_none());
     }
+
+    #[test]
+    #[cfg(target_os = "haiku")]
+    fn test_retrieve_time_zone_on_haiku_platforms() {
+        let timezone = super::get_timezone().unwrap();
+        assert!(!timezone.is_empty());
+    }
 }


### PR DESCRIPTION
Some changes to get `iana-time-zone-haiku`'s fallback code compiling and working correctly on non-Haiku hosts:

- Only link to `be` lib when the target is a Haiku target triple.
- Parse the target triple in `build.rs` from the `TARGET` env var which is set by Cargo.
- Fix cargo pragmas in `build.rs` to properly emit `rerun-if-changed` directives.
- Use C++11 namespace declaration syntax (the current `implementation.cc` file used C++17 syntax which I imagine was not caught because `-std=c++11` is only passed if supported by the host cxx compiler).
- Add CI to build and test `iana-time-zone-haiku` on macOS, Linux, and Windows.
- Add CI to run `cargo check` and `cargo clippy` on `iana-time-zone-haiku`.
- Add standard set of lints to `iana-time-zone-haiku`. Extracted from #76.
- Add `Cargo.toml` keywords and categories to `iana-time-zone-haiku`.
- Fix typo where crate level docs were incorrectly declared with `///` (changed to `//!`)
- Add docs to `iana_time_zone_haiku::get_timezone()`.
- Add example to `iana_time_zone_haiku::get_timezone()`.
- Add smoke test for `iana_time_zone_haiku::get_timezone()` to ensure the fallback routine returns `None` on all non-Haiku platforms.
- Add smoke test for `iana_time_zone_haiku::get_timezone()` on Haiku to ensure `Some` is returned and that the resulting string is non-empty.