### PR TITLE
Add and fix a baseline set of warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -195,6 +195,9 @@ jobs:
           - ""
           - "-Zminimal-versions"
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
+      RUST_BACKTRACE: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -211,7 +214,7 @@ jobs:
         env:
           RUSTC_BOOTSTRAP: 1
       - run: cargo check --all-targets
-      - run: cargo clippy --all-targets -- -D warnings
+      - run: cargo clippy --all-targets
 
   no-docker-image-check-only:
     runs-on: ubuntu-latest

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ impl std::error::Error for GetTimezoneError {
 }
 
 impl std::fmt::Display for GetTimezoneError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         f.write_str(match self {
             GetTimezoneError::FailedParsingString => "GetTimezoneError::FailedParsingString",
             GetTimezoneError::IoError(err) => return err.fmt(f),
@@ -88,7 +88,7 @@ impl std::fmt::Display for GetTimezoneError {
     }
 }
 
-impl std::convert::From<std::io::Error> for GetTimezoneError {
+impl From<std::io::Error> for GetTimezoneError {
     fn from(orig: std::io::Error) -> Self {
         GetTimezoneError::IoError(orig)
     }
@@ -99,7 +99,7 @@ impl std::convert::From<std::io::Error> for GetTimezoneError {
 /// See the module-level documentatation for a usage example and more details
 /// about this function.
 #[inline]
-pub fn get_timezone() -> std::result::Result<String, crate::GetTimezoneError> {
+pub fn get_timezone() -> Result<String, GetTimezoneError> {
     platform::get_timezone_inner()
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,16 @@
+#![warn(clippy::all)]
+#![warn(clippy::cargo)]
+#![warn(clippy::undocumented_unsafe_blocks)]
+#![allow(unknown_lints)]
+#![warn(missing_copy_implementations)]
+#![warn(missing_debug_implementations)]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+#![warn(trivial_casts, trivial_numeric_casts)]
+#![warn(unsafe_op_in_unsafe_fn)]
+#![warn(unused_qualifications)]
+#![warn(variant_size_differences)]
+
 //! get the IANA time zone for the current system
 //!
 //! This small utility crate provides the

--- a/src/tz_macos.rs
+++ b/src/tz_macos.rs
@@ -58,7 +58,7 @@ mod system_time_zone {
         ///
         /// The lifetime of the `StringRef` is bound to our lifetime. Mutable
         /// access is also prevented by taking a reference to `self`.
-        pub(crate) fn name(&self) -> Option<super::string_ref::StringRef<Self>> {
+        pub(crate) fn name(&self) -> Option<super::string_ref::StringRef<'_, Self>> {
             // SAFETY: `SystemTimeZone` is only ever created with a valid `CFTimeZoneRef`.
             let string = unsafe { CFTimeZoneGetName(self.0) };
             if string.is_null() {


### PR DESCRIPTION
- Add a reasonable default set of warnings to `lib.rs`.
- Warn on missing unsafe documentation via clippy.
- Warn on unsafe op in unsafe fn.
- Add `RUSTFLAGS="-D warnings"` to `check` job in CI
- Add rust2018 idioms lint and fix warnings.
- Add `clippy::cargo` lint group and add missing package metadata to the haiku platform crate.

I've only tested these changes on macOS, and due to the `path` pragma we use, I can't test these changes on other platforms.