### PR TITLE
Scope 'push' GitHub Actions workflow trigger to 'main' branch

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,8 @@ name: build
 
 on:
   push:
-    branches: [ '**' ]
+    branches:
+      - main
   pull_request:
     branches: [ '**' ]
   schedule:


### PR DESCRIPTION
The previous configuration causes all jobs to run twice on every PR. We should consider protecting the main branch and requiring PRs if that is not already the case.