### PR TITLE
Support /etc/localtime as a symlink to /etc/zoneinfo

### DIFF
--- a/src/tz_linux.rs
+++ b/src/tz_linux.rs
@@ -27,6 +27,8 @@ fn etc_localtime() -> Result<String, crate::GetTimezoneError> {
     const PREFIXES: &[&str] = &[
         "/usr/share/zoneinfo/",   // absolute path
         "../usr/share/zoneinfo/", // relative path
+        "/etc/zoneinfo/",         // absolute path for NixOS
+        "../etc/zoneinfo/",       // relative path for NixOS
     ];
     let mut s = read_link("/etc/localtime")?
         .into_os_string()


### PR DESCRIPTION
NixOS uses /etc/zoneinfo instead of /usr/share/zoneinfo as the target for the /etc/localtime symlink.

It also patches systemd to look there instead:
https://github.com/NixOS/nixpkgs/blob/8ff7b290e6dd47d7ed24c6d156ba60fc3c83f100/pkgs/os-specific/linux/systemd/0009-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch