### PR TITLE
remove lint causing breakage on rust 1.45-1.51

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
 #![warn(trivial_casts, trivial_numeric_casts)]
-#![warn(unsafe_op_in_unsafe_fn)]
 #![warn(unused_qualifications)]
 #![warn(variant_size_differences)]
 


### PR DESCRIPTION
This fixes #82

As described there:

> Ya'll have `unknown_lints`. In 1.38 `unsafe_op_in_unsafe_fn` doesn't exist, so it's fine. In stable `unsafe_op_in_unsafe_fn` is stable so its fine.

> But in 1.48 `unsafe_op_in_unsafe_fn` is unstable. So it's not fine.