### PR TITLE
Use less cross-compilations in CI tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -119,9 +119,6 @@ jobs:
           - x86_64-unknown-illumos
           - x86_64-unknown-netbsd
           - x86_64-linux-android
-          - i686-linux-android
-          - arm-linux-androideabi
-          - aarch64-linux-android
           - sparcv9-sun-solaris
         versions:
           - ""
@@ -165,8 +162,6 @@ jobs:
           - "1.48"
           - stable
         target:
-          - aarch64-apple-ios-sim
-          - aarch64-apple-ios
           - x86_64-apple-ios
         versions:
           - ""


### PR DESCRIPTION
We aren't using any assembly code, but only the official C interface for our Android and MacOS implementation. It's exceedingly unlikely that the compilation for e.g. AArch64 could fail if it succeeds for x86-64.

Should hopefully resolve #80.