### PR TITLE
Update `cxx-build` version constraint in haiku crate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -302,8 +302,10 @@ jobs:
         runs-on: [ubuntu-20.04, windows-2022, macos-12]
         toolchain:
           - stable
+          - nightly
         versions:
           - ""
+          - "-Zminimal-versions"
     runs-on: ${{ matrix.runs-on }}
     env:
       RUSTFLAGS: -D warnings
@@ -332,8 +334,10 @@ jobs:
       matrix:
         toolchain:
           - stable
+          - nightly
         versions:
           - ""
+          - "-Zminimal-versions"
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iana-time-zone"
 description = "get the IANA time zone for the current system"
-version = "0.1.53"
+version = "0.1.54"
 authors = [
     "Andrew Straw <strawman@astraw.com>",
     "René Kijewski <rene.kijewski@fu-berlin.de>",
@@ -35,7 +35,7 @@ wasm-bindgen = "0.2.70"
 wasm-bindgen-test = "0.3"
 
 [target.'cfg(target_os = "haiku")'.dependencies]
-iana-time-zone-haiku = { version = "0.1.1", path = "haiku" }
+iana-time-zone-haiku = { version = "0.1.2", path = "haiku" }
 
 [workspace]
 members = [".", "haiku"]

--- a/haiku/Cargo.toml
+++ b/haiku/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iana-time-zone-haiku"
 description = "iana-time-zone support crate for Haiku OS"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["René Kijewski <crates.io@k6i.de>"]
 repository = "https://github.com/strawlab/iana-time-zone"
 license = "MIT OR Apache-2.0"
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cxx = "1.0.34"
+cxx = "1.0.79"
 
 [build-dependencies]
-cxx-build = "1.0.34"
+cxx-build = "1.0.79"


### PR DESCRIPTION
cxx-build before v1.0.79 did not properly declare its minimum version bound on `codespan-reporting`, which caused `cxx-build` (and `iana-time-zone-haiku`) to fail building when used with a `-Zminimal-versions` lockfile.

I previously reported this upstream to `cxx`:

- https://github.com/dtolnay/cxx/pull/1111

The fix was included in v1.0.79.