### PR TITLE
CI: update to cross 0.2.5

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -146,14 +146,14 @@ jobs:
         # The command is derived from `cargo-quickinstall`'s description:
         # https://github.com/cargo-bins/cargo-quickinstall/blob/49f09436/README.md#use-in-ci-systems
         #
-        # I.e. Download the file into STDOUT, follow redirects, don't give status reports, except
+        # I.e. download the file into STDOUT, follow redirects, don't give status reports, except
         # if there are HTTP errors, and in case of HTTP errors don't pipe out anything at all.
         # Extract everything into Cargo's `cargo install` destination, which is in your $PATH already.
         #
         # Updated pre-compiled binaries can be found in <https://github.com/cargo-bins/cargo-quickinstall/releases>
         # by searching for their project name.
       - name: Install "cross"
-        run: curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-quickinstall/releases/download/cross-0.2.4-x86_64-unknown-linux-gnu/cross-0.2.4-x86_64-unknown-linux-gnu.tar.gz | tar -xzvvf - -C $HOME/.cargo/bin
+        run: curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-quickinstall/releases/download/cross-0.2.5-x86_64-unknown-linux-gnu/cross-0.2.5-x86_64-unknown-linux-gnu.tar.gz | tar -xzvvf - -C $HOME/.cargo/bin
 
       - run: cross build --target ${{ matrix.target }} --examples
 
@@ -192,7 +192,7 @@ jobs:
         env:
           RUSTC_BOOTSTRAP: 1
       - name: Install "cross"
-        run: curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-quickinstall/releases/download/cross-0.2.4-x86_64-apple-darwin/cross-0.2.4-x86_64-apple-darwin.tar.gz | tar -xzvvf - -C $HOME/.cargo/bin
+        run: curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-quickinstall/releases/download/cross-0.2.5-x86_64-apple-darwin/cross-0.2.5-x86_64-apple-darwin.tar.gz | tar -xzvvf - -C $HOME/.cargo/bin
       - run: cross build --target ${{ matrix.target }} --examples
 
   check:


### PR DESCRIPTION
Fixes the "cannot find -lmemstat" problem for `x86_64-unknown-freebsd`.