### PR TITLE
Allow crate users to opt out of some platform support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iana-time-zone"
 description = "get the IANA time zone for the current system"
-version = "0.1.56"
+version = "0.2.0"
 authors = [
     "Andrew Straw <strawman@astraw.com>",
     "René Kijewski <rene.kijewski@fu-berlin.de>",
@@ -15,27 +15,44 @@ readme = "README.md"
 edition = "2018"
 
 [features]
+default = ["platform-all"]
+# Allow users to opt out of platform support for platforms that require third
+# party dependencies. Disabling any of these platforms (i.e. with
+# `default-features = false`) will prevent the platform dependencies from
+# appearing in downstream applications' `Cargo.lock`.
+platform-all = [
+  "platform-android",
+  "platform-apple",
+  "platform-haiku",
+  "platform-wasm",
+  "platform-windows",
+]
+platform-android = ["android_system_properties"]
+platform-apple = ["core-foundation-sys"]
+platform-haiku = ["iana-time-zone-haiku"]
+platform-wasm = ["js-sys", "wasm-bindgen"]
+platform-windows = ["windows"]
 # When enabled, the library will succeed to compile for unknown target platforms, and return an `Err(GetTimezoneError::OsError)` at runtime.
 fallback = []
 
 [target.'cfg(target_os = "android")'.dependencies]
-android_system_properties = "0.1.5"
+android_system_properties = { version = "0.1.5", optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-core-foundation-sys = "0.8.3"
+core-foundation-sys = { version = "0.8.3", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.48.0", features = [ "Globalization" ] }
+windows = { version = "0.48.0", features = [ "Globalization" ], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys = "0.3.50"
-wasm-bindgen = "0.2.70"
+js-sys = { version = "0.3.50", optional = true }
+wasm-bindgen = { version = "0.2.70", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 
 [target.'cfg(target_os = "haiku")'.dependencies]
-iana-time-zone-haiku = { version = "0.1.1", path = "haiku" }
+iana-time-zone-haiku = { version = "0.1.1", path = "haiku", optional = true }
 
 [workspace]
 members = [".", "haiku"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,10 +34,23 @@
 mod ffi_utils;
 
 #[cfg_attr(target_os = "linux", path = "tz_linux.rs")]
-#[cfg_attr(target_os = "windows", path = "tz_windows.rs")]
-#[cfg_attr(any(target_os = "macos", target_os = "ios"), path = "tz_macos.rs")]
 #[cfg_attr(
-    all(target_arch = "wasm32", not(target_os = "wasi")),
+    all(feature = "platform-windows", target_os = "windows"),
+    path = "tz_windows.rs"
+)]
+#[cfg_attr(
+    all(
+        feature = "platform-apple",
+        any(target_os = "macos", target_os = "ios")
+    ),
+    path = "tz_macos.rs"
+)]
+#[cfg_attr(
+    all(
+        feature = "platform-wasm",
+        target_arch = "wasm32",
+        not(target_os = "wasi")
+    ),
     path = "tz_wasm32.rs"
 )]
 #[cfg_attr(
@@ -52,8 +65,14 @@ mod ffi_utils;
     any(target_os = "illumos", target_os = "solaris"),
     path = "tz_illumos.rs"
 )]
-#[cfg_attr(target_os = "android", path = "tz_android.rs")]
-#[cfg_attr(target_os = "haiku", path = "tz_haiku.rs")]
+#[cfg_attr(
+    all(feature = "platform-android", target_os = "android"),
+    path = "tz_android.rs"
+)]
+#[cfg_attr(
+    all(feature = "platform-haiku", target_os = "haiku"),
+    path = "tz_haiku.rs"
+)]
 mod platform;
 
 /// Error types

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -5,5 +5,8 @@ pub fn get_timezone_inner() -> std::result::Result<String, crate::GetTimezoneErr
 #[cfg(not(feature = "fallback"))]
 compile_error!(
     "iana-time-zone is currently implemented for Linux, Window, MacOS, FreeBSD, NetBSD, \
-    OpenBSD, Dragonfly, WebAssembly (browser), iOS, Illumos, Android, Solaris and Haiku.",
+    OpenBSD, Dragonfly, WebAssembly (browser), iOS, Illumos, Android, Solaris and Haiku. \
+    If you are seeing this error on a supported platform, ensure the platform support \
+    Cargo feature is enabled, e.g. platform-android, platform-apple, platform-haiku, \
+    platform-wasm, platform-windows, or platform-all.",
 );


### PR DESCRIPTION
We have gotten several inbound tickets with users expressing concern over the inclusion of `cxx` to support the haiku platform. Additionally, for my personal use, I would prefer to be able to prune things like `wasm-bindgen` from my lockfile when not expressly enabling Wasm platform support, similar to the approach the `getrandom` crate takes.

This commit adds cargo features which allow disabling platform support for each platform that requires a third party dependency. Currently, that set of platforms is:

- android
- all apple targets
- haiku
- wasm
- windows

This commit adds a new default feature, `platform-all`, which retains the existing behavior of all platforms being enabled by default. `platform-all` is a meta feature which enables all of the other platform support features.

For example, to disable haiku support, users would add the following to their `Cargo.toml`:

```toml
iana-time-zone = { version = "0.2", default-features = false, features = ["platform-android", "platform-apple", "platform-wasm", "platform-windows"] }
```

The addition of a new default feature is a breaking change because it may break the build for folks currently depending on this crate with `default-features = false`.

I'm not sure if this is the direction we want to go, but it would address the ask from these tickets:

- https://github.com/strawlab/iana-time-zone/issues/89
- https://github.com/strawlab/iana-time-zone/issues/88

I know that cargo won't build deps unless compiling for a particular platform, but practically, most users don't want or need Haiku or Wasm support. These targets have heavy dependencies which end up in the lock file. Deps in the lock file have a carrying cost in terms of supply chain risk and need for patching/updating.