### PR TITLE
Use C ABI for haiku platform support native bindings

### DIFF
--- a/haiku/Cargo.toml
+++ b/haiku/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iana-time-zone-haiku"
 description = "iana-time-zone support crate for Haiku OS"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["René Kijewski <crates.io@k6i.de>"]
 repository = "https://github.com/strawlab/iana-time-zone"
 license = "MIT OR Apache-2.0"
@@ -11,7 +11,6 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cxx = "1.0.34"
 
 [build-dependencies]
-cxx-build = "1.0.34"
+cc = "1.0.79"

--- a/haiku/build.rs
+++ b/haiku/build.rs
@@ -1,7 +1,9 @@
 use std::env;
 
 fn main() {
-    cxx_build::bridge("src/lib.rs")
+    cc::Build::new()
+        .warnings(false)
+        .cpp(true)
         .file("src/implementation.cc")
         .flag_if_supported("-std=c++11")
         .compile("tz_haiku");

--- a/haiku/src/implementation.cc
+++ b/haiku/src/implementation.cc
@@ -1,5 +1,4 @@
-#include "iana-time-zone-haiku/src/interface.h"
-#include "iana-time-zone-haiku/src/lib.rs.h"
+#include <cstddef>
 
 #ifdef __HAIKU__
 
@@ -10,12 +9,13 @@
 #include <String.h>
 #include <TimeZone.h>
 
-namespace iana_time_zone_haiku {
-size_t get_tz(rust::Slice<uint8_t> buf) {
+extern "C" {
+
+size_t iana_time_zone_haiku_get_tz(char *buf, size_t buf_size) {
     try {
         static_assert(sizeof(char) == sizeof(uint8_t), "Illegal char size");
 
-        if (buf.empty()) {
+        if (buf_size == 0) {
             return 0;
         }
 
@@ -38,7 +38,7 @@ size_t get_tz(rust::Slice<uint8_t> buf) {
         }
 
         size_t length(ilength);
-        if (length > buf.size()) {
+        if (length > buf_size) {
             return 0;
         }
 
@@ -49,18 +49,19 @@ size_t get_tz(rust::Slice<uint8_t> buf) {
             return 0;
         }
 
-        std::memcpy(buf.data(), sname, length);
+        std::memcpy(buf, sname, length);
         return length;
     } catch (...) {
         return 0;
     }
 }
-}  // namespace iana_time_zone_haiku
+}  // extern "C"
 
 #else
 
-namespace iana_time_zone_haiku {
-size_t get_tz(rust::Slice<uint8_t>) { return 0; }
-}  // namespace iana_time_zone_haiku
+extern "C" {
+
+size_t iana_time_zone_haiku_get_tz(char *buf, size_t buf_size) { return 0; }
+}  // extern "C"
 
 #endif

--- a/haiku/src/interface.h
+++ b/haiku/src/interface.h
@@ -1,9 +1,0 @@
-#pragma once
-
-#include "rust/cxx.h"
-
-#include <cstddef>
-
-namespace iana_time_zone_haiku {
-size_t get_tz(rust::Slice<uint8_t> buf);
-}


### PR DESCRIPTION
The haiku platform support crate uses `cxx` and `cxx-build` for its native bindings to the `be` SDK, however `cxx` is a heavy dependency which is not necessary for interfacing with a C++ native library.

Replace `cxx-build` with `cc` set to build for C++ mode. Instead of exporting a C++ ABI interace and bridging with `cxx`, use the C ABI (extern "C" in both C++ and Rust).

This introduces one line of `unsafe` which is documented with SAFETY comments (and is not meaningfully different from the C++ bridge). The C++ source file is updated to use the new function arguments.

As an opportunistic refactor, add a `#[must_use]` attribute to `get_timezone` in the haiku crate.