### PR TITLE
CI use rustsec/audit-check for node16

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -223,7 +223,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Audit
-        uses: actions-rs/audit-check@v1
+        uses: rustsec/audit-check@v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Node12 is deprecated from Github's CI and actions-rs/audit-check seems unmaintained. The works around
https://github.com/actions-rs/audit-check/issues/227