### PR TITLE
Allow version range for `windows` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.58] - unreleased
+### Changed
+- allow version range for `windows` dependency ([#112](https://github.com/strawlab/iana-time-zone/pull/112))
+
 ## [0.1.57] - 2023-06-07
 ### Changed
 - implement OpenWRT support ([#109](https://github.com/strawlab/iana-time-zone/pull/109))
@@ -252,6 +256,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Implement for Linux, Windows, MacOS
 
+[0.1.58]: https://github.com/strawlab/iana-time-zone/releases/tag/v0.1.58
+[0.1.57]: https://github.com/strawlab/iana-time-zone/releases/tag/v0.1.57
 [0.1.56]: https://github.com/strawlab/iana-time-zone/releases/tag/v0.1.56
 [0.1.55]: https://github.com/strawlab/iana-time-zone/releases/tag/v0.1.55
 [0.1.54]: https://github.com/strawlab/iana-time-zone/releases/tag/v0.1.54

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "iana-time-zone"
 description = "get the IANA time zone for the current system"
-version = "0.1.57"
+version = "0.1.58"
 authors = [
     "Andrew Straw <strawman@astraw.com>",
     "René Kijewski <rene.kijewski@fu-berlin.de>",
     "Ryan Lopopolo <rjl@hyperbo.la>",
-    ]
+]
 repository = "https://github.com/strawlab/iana-time-zone"
 license = "MIT OR Apache-2.0"
 keywords = ["IANA", "time"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ android_system_properties = "0.1.5"
 core-foundation-sys = "0.8.3"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.48.0", features = [ "Globalization" ] }
+windows = { version = ">= 0.30, < 0.52", features = [ "Globalization" ] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.50"


### PR DESCRIPTION
`iana-time-zone` works with any `windows` version since `0.30.0`. We don't have to care which version the user actually uses. We only need to make sure that the selected version is not too old. Let `cargo` decide everything else.

The newest version of `windows`, `0.51.0`, has an msrv of `1.56`. If a user of `iana-time-zone` is not able or willing to update their rust installation, and want to continue using rustc `1.48`, they can select an older version of the `windows` crate, and still receive any updates `iana-time-zone` might have in the future.

Resolves #111.