### PR TITLE
Implement for GNU Hurd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.58] - 2023-10-02
+### Added
+- implement GNU Hurd support ([#121](https://github.com/strawlab/iana-time-zone/pull/121))
+
 ## [0.1.57] - 2023-06-07
-### Changed
+### Added
 - implement OpenWRT support ([#109](https://github.com/strawlab/iana-time-zone/pull/109))
 
 ## [0.1.56] - 2023-04-03
@@ -252,6 +256,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Implement for Linux, Windows, MacOS
 
+[0.1.58]: https://github.com/strawlab/iana-time-zone/releases/tag/v0.1.58
+[0.1.57]: https://github.com/strawlab/iana-time-zone/releases/tag/v0.1.57
 [0.1.56]: https://github.com/strawlab/iana-time-zone/releases/tag/v0.1.56
 [0.1.55]: https://github.com/strawlab/iana-time-zone/releases/tag/v0.1.55
 [0.1.54]: https://github.com/strawlab/iana-time-zone/releases/tag/v0.1.54

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 #[allow(dead_code)]
 mod ffi_utils;
 
-#[cfg_attr(target_os = "linux", path = "tz_linux.rs")]
+#[cfg_attr(any(target_os = "linux", target_os = "hurd"), path = "tz_linux.rs")]
 #[cfg_attr(target_os = "windows", path = "tz_windows.rs")]
 #[cfg_attr(any(target_os = "macos", target_os = "ios"), path = "tz_macos.rs")]
 #[cfg_attr(


### PR DESCRIPTION
The default GNU Hurd installation runs on Debian, so it works the same as for Linux.