### PR TITLE
correct windows-core dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ android_system_properties = "0.1.5"
 core-foundation-sys = "0.8.3"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-core = { version = ">=0.50, <=0.53" }
+windows-core = { version = ">=0.50, <=0.52" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.50"


### PR DESCRIPTION
As noted in https://github.com/strawlab/iana-time-zone/pull/125#issuecomment-1875367853, commit d3a9e0a21f4c4ded969d02ceec0a908cd7cd0ca4 introduced a potentially breaking change. This is the fix.

@MarijnS95 thanks for the tip. Do you know if there a public issue regarding this dependabot bug that we can link to? I spent a little bit of time looking around https://github.com/dependabot/dependabot-core/issues but didn't find anything relevant.

I would release this as 0.1.60.

Shall we then yank 0.1.59?