### PR TITLE
Depend on wasm-bindgen 0.2.89 or higher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ core-foundation-sys = "0.8.3"
 windows-core = { version = ">=0.50, <=0.52" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys = "0.3.50"
-wasm-bindgen = "0.2.70"
+js-sys = "0.3.66"
+wasm-bindgen = "0.2.89"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3"


### PR DESCRIPTION
wasm-bindgen 0.2.70 is not compatible with a wasm ABI change that rustc wishes to enable by default for wasm32-unknown-unknown, currently gated behind passing the -Zwasm-c-abi flag to rustc.

wasm-bindgen 0.2.89 should exhibit seamless behavior before and after the ABI change to match the C ABI, so depend on that.

For more information, see
- https://github.com/rust-lang/rust/issues/115666
- https://github.com/rust-lang/rust/pull/117918
- https://github.com/rust-lang/rust/issues/122532