### PR TITLE
ci: allow duplicated `cfg-if` crate

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,3 @@
+allowed-duplicate-crates = ["cfg-if"]
+avoid-breaking-exported-api = true
+msrv = "1.48.0"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -235,8 +235,8 @@ jobs:
         run: cargo generate-lockfile ${{ matrix.versions }}
         env:
           RUSTC_BOOTSTRAP: 1
-      - run: cargo check --all-targets
-      - run: cargo clippy --all-targets
+      - run: cargo check --all-targets --workspace
+      - run: cargo clippy --all-targets --workspace -- -D warnings
 
   no-docker-image-check-only:
     runs-on: ubuntu-latest
@@ -355,7 +355,7 @@ jobs:
           RUSTC_BOOTSTRAP: 1
       - run: cargo check --all-targets
         working-directory: haiku
-      - run: cargo clippy --all-targets
+      - run: cargo clippy --all-targets -- -D warnings
         working-directory: haiku
 
   check-all-versions:


### PR DESCRIPTION
Fixes some warnings that occur in #134 with `-Zminimal-versions`.