### PR TITLE
Fix up clippy errors from nightly on macos and linux targets

### DIFF
--- a/src/tz_linux.rs
+++ b/src/tz_linux.rs
@@ -89,7 +89,7 @@ mod openwrt {
             }
         }
 
-        timezone.ok_or_else(|| crate::GetTimezoneError::OsError)
+        timezone.ok_or(crate::GetTimezoneError::OsError)
     }
 
     #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]

--- a/src/tz_macos.rs
+++ b/src/tz_macos.rs
@@ -74,7 +74,7 @@ mod system_time_zone {
 mod string_ref {
     //! create safe wrapper around `CFStringRef`
 
-    use std::convert::TryInto;
+    use core::convert::TryInto;
 
     use core_foundation_sys::base::{Boolean, CFRange};
     use core_foundation_sys::string::{
@@ -100,7 +100,10 @@ mod string_ref {
             // SAFETY: `StringRef` is only ever created with a valid `CFStringRef`.
             let v = unsafe { CFStringGetCStringPtr(self.string, kCFStringEncodingUTF8) };
             if !v.is_null() {
-                // SAFETY: `CFStringGetCStringPtr()` returns NUL-terminated strings.
+                // SAFETY: `CFStringGetCStringPtr()` returns NUL-terminated
+                // strings and will return NULL if the internal representation
+                // of the `CFString`` is not compatible with the requested
+                // encoding.
                 let v = unsafe { std::ffi::CStr::from_ptr(v) };
                 if let Ok(v) = v.to_str() {
                     return Some(v);
@@ -119,8 +122,8 @@ mod string_ref {
                 length,
             };
 
+            // SAFETY: `StringRef` is only ever created with a valid `CFStringRef`.
             let converted_bytes = unsafe {
-                // SAFETY: `StringRef` is only ever created with a valid `CFStringRef`.
                 CFStringGetBytes(
                     self.string,
                     range,


### PR DESCRIPTION
no code changes in the unsafe macos bits, just shuffling some comments around to make the linter happy. I've included the additional safety context from https://github.com/strawlab/iana-time-zone/pull/147#issuecomment-2618070786.

This should fix the failing builds on main.