### PR TITLE
Implement for OpenHarmony

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - bump msrv to 1.61 ([#157](https://github.com/strawlab/iana-time-zone/pull/157))
 
 ### Added
-- Added support for tvOS, watchOS and visionOS.
+- Added support for tvOS, watchOS and visionOS ([#146](https://github.com/strawlab/iana-time-zone/pull/146)).
+- implement OpenHarmony support ([#150](https://github.com/strawlab/iana-time-zone/pull/150))
 
 ## [0.1.61] - 2024-09-16
 

--- a/src/ffi_utils.rs
+++ b/src/ffi_utils.rs
@@ -4,7 +4,7 @@
 use std::ffi::CStr;
 
 /// A buffer to store the timezone name when calling the C API.
-#[cfg(any(test, target_vendor = "apple"))]
+#[cfg(any(test, target_vendor = "apple", target_env = "ohos"))]
 pub(crate) mod buffer {
     /// The longest name in the IANA time zone database is 32 ASCII characters long.
     pub const MAX_LEN: usize = 64;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,11 @@
 #[allow(dead_code)]
 mod ffi_utils;
 
-#[cfg_attr(any(target_os = "linux", target_os = "hurd"), path = "tz_linux.rs")]
+#[cfg_attr(
+    any(all(target_os = "linux", not(target_env = "ohos")), target_os = "hurd"),
+    path = "tz_linux.rs"
+)]
+#[cfg_attr(all(target_os = "linux", target_env = "ohos"), path = "tz_ohos.rs")]
 #[cfg_attr(target_os = "windows", path = "tz_windows.rs")]
 #[cfg_attr(target_vendor = "apple", path = "tz_darwin.rs")]
 #[cfg_attr(

--- a/src/tz_ohos.rs
+++ b/src/tz_ohos.rs
@@ -1,0 +1,47 @@
+//! OpenHarmony doesn't have `/etc/localtime`, we have to use it's "Time Service" to get the timezone information:
+//!
+//! - [API Refence](https://gitee.com/openharmony/docs/blob/43726785b4033887cd1a838aaaca5e255897a71e/en/application-dev/reference/apis-basic-services-kit/_time_service.md#oh_timeservice_gettimezone)
+
+use crate::ffi_utils::buffer::{tzname_buf, MAX_LEN};
+use crate::GetTimezoneError;
+use std::ffi::{c_char, CStr};
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[repr(C)]
+#[allow(non_camel_case_types)]
+#[allow(dead_code)]
+enum TimeService_ErrCode {
+    TIMESERVICE_ERR_OK = 0,
+    TIMESERVICE_ERR_INTERNAL_ERROR = 13000001,
+    TIMESERVICE_ERR_INVALID_PARAMETER = 13000002,
+}
+
+#[link(name = "time_service_ndk", kind = "dylib")]
+extern "C" {
+    fn OH_TimeService_GetTimeZone(timeZone: *mut c_char, len: u32) -> TimeService_ErrCode;
+}
+
+/// TODO: Change this `CStr::from_bytes_until_nul` once MSRV was bumped above 1.69.0
+fn from_bytes_until_nul(bytes: &[u8]) -> Option<&CStr> {
+    let nul_pos = bytes.iter().position(|&b| b == 0)?;
+    // SAFETY:
+    // 1. nul_pos + 1 <= bytes.len()
+    // 2. We know there is a nul byte at nul_pos, so this slice (ending at the nul byte) is a well-formed C string.
+    Some(unsafe { CStr::from_bytes_with_nul_unchecked(&bytes[..=nul_pos]) })
+}
+
+pub(crate) fn get_timezone_inner() -> Result<String, GetTimezoneError> {
+    let mut time_zone = tzname_buf();
+    // SAFETY:
+    // `time_zone` is a valid buffer with a length of 40 bytes.
+    let ret = unsafe {
+        OH_TimeService_GetTimeZone(time_zone.as_mut_ptr().cast::<c_char>(), MAX_LEN as u32 - 1)
+    };
+    if ret != TimeService_ErrCode::TIMESERVICE_ERR_OK {
+        return Err(GetTimezoneError::OsError);
+    }
+    from_bytes_until_nul(&time_zone)
+        .and_then(|x| x.to_str().ok())
+        .map(|x| x.to_owned())
+        .ok_or(GetTimezoneError::OsError)
+}


### PR DESCRIPTION
OpenHarmony(or say [HarmonyOS NEXT](https://en.wikipedia.org/wiki/HarmonyOS_NEXT)) is forked from musl/Linux, but it doesn't have `/etc/localtime`, we have to use it's ["Time Service" function](https://gitee.com/openharmony/docs/blob/43726785b4033887cd1a838aaaca5e255897a71e/en/application-dev/reference/apis-basic-services-kit/time__service_8h.md) to get the timezone information.

Here is the test output:
```shell
$ cargo dinghy -d ohos test -Zbuild-std -- tests::get_current --nocapture
   Targeting platform auto-ohos-arm64-v8a and device 127.0.0.1:5555
   Compiling iana-time-zone v0.1.61 (/Users/donoughliu/code/iana-time-zone)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.49s
     Running unittests src/lib.rs (target/aarch64-unknown-linux-ohos/debug/deps/iana_time_zone-c96255da1500e341)
   Targeting platform auto-ohos-arm64-v8a and device 127.0.0.1:5555
  Installing iana_time_zone-c96255da1500e341 to 127.0.0.1:5555
     Running iana_time_zone-c96255da1500e341 on 127.0.0.1:5555

running 1 test
current: Asia/Shanghai
test tests::get_current ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s
```