### PR TITLE
make doctest no longer ignored

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ wasm-bindgen-test = "0.3"
 [target.'cfg(target_os = "haiku")'.dependencies]
 iana-time-zone-haiku = { version = "0.1.1", path = "haiku" }
 
+[dev-dependencies]
+chrono-tz = "0.10.1"
+
 [workspace]
 members = [".", "haiku"]
 default-members = ["."]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,9 +25,10 @@
 //! The resulting string can be parsed to a
 //! [`chrono-tz::Tz`](https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html)
 //! variant like this:
-//! ```ignore
+//! ```rust
 //! let tz_str = iana_time_zone::get_timezone()?;
 //! let tz: chrono_tz::Tz = tz_str.parse()?;
+//! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 
 #[allow(dead_code)]


### PR DESCRIPTION
This removes `ignored` from a doctest. The reason it was ignored was to not require the `chrono-tz` crate, but this can be done with a dev-dependency.