### PR TITLE
Fix Apple timezone caching issue by resetting system timezone cache

### DIFF
--- a/examples/get_timezone_loop.rs
+++ b/examples/get_timezone_loop.rs
@@ -1,0 +1,13 @@
+use std::thread;
+use std::time::Duration;
+
+use iana_time_zone::{get_timezone, GetTimezoneError};
+
+const WAIT: Duration = Duration::from_secs(1);
+
+fn main() -> Result<(), GetTimezoneError> {
+    loop {
+        println!("{}", get_timezone()?);
+        thread::sleep(WAIT);
+    }
+}


### PR DESCRIPTION
Previously, changing the macOS system timezone while a process was running would not be reflected in subsequent calls to `get_timezone()`. This was due to `CFTimeZoneCopySystem` internally caching the timezone upon the first call.

This commit addresses the issue by explicitly calling `CFTimeZoneResetSystem` before each retrieval of the timezone, forcing CoreFoundation to invalidate and refresh its cached timezone value.

This approach incurs a minimal performance penalty (one lock and minor allocations) but ensures correctness and consistency with behavior observed on other platforms (Windows, Linux).

Closes #145.

cc @kathoum. This PR is the proposal to round out the investigation in https://github.com/strawlab/iana-time-zone/issues/145#issuecomment-2745934606.