### PR TITLE
Upgrade macOS runners, test on aarch64, use latest stable XCode

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    branches: [ '**' ]
+    branches: ["**"]
   schedule:
     # At 23:25 on Thursday.
     - cron: "25 23 * * 4"
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-22.04, windows-2022, macos-13]
+        runs-on: [ubuntu-22.04, windows-2022, macos-14, macos-14-arm64]
         toolchain:
           - "1.48"
           - stable
@@ -30,14 +30,21 @@ jobs:
           - runs-on: windows-2022
             toolchain: "1.48"
             versions: ""
+          # The rust toolchain did not have a macOS aarch64 target in 1.48.0.
+          - runs-on: macos-14-arm64
+            toolchain: "1.48"
+            versions: ""
+          - runs-on: macos-14-arm64
+            toolchain: "1.48"
+            versions: "-Zminimal-versions"
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - uses: maxim-lobanov/setup-xcode@v1
-        if: matrix.runs-on == 'macos-13' && matrix.toolchain == '1.48'
+        if: runner.os == 'macOS' && matrix.toolchain == '1.48'
         with:
-          xcode-version: "13.4.1"
+          xcode-version: "latest-stable"
       - name: Install Rust
         run: |
           rustup toolchain install ${{ matrix.toolchain }} --profile minimal --no-self-update
@@ -187,7 +194,7 @@ jobs:
           # Support for this target was added quite recently.
           - target: aarch64-apple-ios-sim
           - toolchain: "1.48"
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -295,7 +302,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-22.04, windows-2022, macos-13]
+        runs-on: [ubuntu-22.04, windows-2022, macos-14, macos-14-arm64]
         toolchain:
           - stable
         versions:


### PR DESCRIPTION
Choosing XCode version `latest-stable` to minimize maintenance burden.

macOS 15 runners come out next week (March 25, 2025).