### PR TITLE
Update Unicode license in cargo deny config

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,4 +1,4 @@
 [licenses]
 version = 2
-allow = ["Apache-2.0", "MIT", "Unicode-DFS-2016"]
+allow = ["Apache-2.0", "MIT", "Unicode-3.0"]
 private = { ignore = true }


### PR DESCRIPTION
Unicode 16.0.0 updated the license for data files from Unicode-2016-DFS to Unicode-3.0. Various crates across the ecosystem have been updating their SPDX specifiers to take this into account, including unicode-ident, which we pull in via syn and wasm-bindgen.