### PR TITLE
Bump MSRV to 1.61.0, matching Chrono

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,3 +1,2 @@
-allowed-duplicate-crates = ["cfg-if"]
 avoid-breaking-exported-api = true
 msrv = "1.61.0"

--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,3 +1,3 @@
 allowed-duplicate-crates = ["cfg-if"]
 avoid-breaking-exported-api = true
-msrv = "1.48.0"
+msrv = "1.61.0"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    branches: [ '**' ]
+    branches: ["**"]
   schedule:
     # At 23:25 on Thursday.
     - cron: "25 23 * * 4"
@@ -24,6 +24,11 @@ jobs:
         versions:
           - ""
           - "-Zminimal-versions"
+        exclude:
+          # package `regex v1.11.1` cannot be built because it requires rustc
+          # 1.65 or newer, while the currently active rustc version is 1.61.0
+          - toolchain: "1.61"
+            versions: ""
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout
@@ -200,6 +205,11 @@ jobs:
         versions:
           - ""
           - "-Zminimal-versions"
+        exclude:
+          # package `cc v1.2.17` cannot be built because it requires rustc 1.63
+          # or newer, while the currently active rustc version is 1.61.0
+          - toolchain: "1.61"
+            versions: ""
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,26 +18,16 @@ jobs:
       matrix:
         runs-on: [ubuntu-22.04, windows-2022, macos-13]
         toolchain:
-          - "1.48"
+          - "1.61"
           - stable
           - nightly
         versions:
           - ""
           - "-Zminimal-versions"
-        exclude:
-          # `windows-core >= 0.51` uses `edition = "2021"`, but users of the library can can use
-          # `windows-core == 0.50` to be rust 1.48 compatible.
-          - runs-on: windows-2022
-            toolchain: "1.48"
-            versions: ""
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: maxim-lobanov/setup-xcode@v1
-        if: matrix.runs-on == 'macos-13' && matrix.toolchain == '1.48'
-        with:
-          xcode-version: "13.4.1"
       - name: Install Rust
         run: |
           rustup toolchain install ${{ matrix.toolchain }} --profile minimal --no-self-update
@@ -62,7 +52,7 @@ jobs:
         include:
           # Without `-Zminimal-versions` a too recent bumpalo version is selected. Newer versions use `edition = "2021"`.
           - versions: "-Zminimal-versions"
-          - toolchain: "1.48"
+          - toolchain: "1.61"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -95,7 +85,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: "lts/*"
       - name: Install "wasm-pack"
         uses: taiki-e/install-action@v2
         with:
@@ -176,17 +166,13 @@ jobs:
       fail-fast: false
       matrix:
         toolchain:
-          - "1.48"
+          - "1.61"
           - stable
         target:
           - x86_64-apple-ios
         versions:
           - ""
           - "-Zminimal-versions"
-        exclude:
-          # Support for this target was added quite recently.
-          - target: aarch64-apple-ios-sim
-          - toolchain: "1.48"
     runs-on: macos-13
     steps:
       - name: Checkout
@@ -208,7 +194,7 @@ jobs:
       fail-fast: false
       matrix:
         toolchain:
-          - "1.48"
+          - "1.61"
           - stable
           - nightly
         versions:
@@ -284,7 +270,7 @@ jobs:
       - name: Setup Node.js runtime
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: "lts/*"
       - name: Install npm
         run: npm i -f -g npm@8.16.0
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -178,6 +178,11 @@ jobs:
         versions:
           - ""
           - "-Zminimal-versions"
+        exclude:
+          # package `regex v1.11.1` cannot be built because it requires rustc
+          # 1.65 or newer, while the currently active rustc version is 1.61.0
+          - toolchain: "1.61"
+            versions: ""
     runs-on: macos-13
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- bump msrv to 1.61 ([#157](https://github.com/strawlab/iana-time-zone/pull/157))
+
 ### Added
 - Added support for tvOS, watchOS and visionOS.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["IANA", "time"]
 categories = ["date-and-time", "internationalization", "os"]
 readme = "README.md"
 edition = "2018"
+rust-version = "1.61.0"
 
 [features]
 # When enabled, the library will succeed to compile for unknown target platforms, and return an `Err(GetTimezoneError::OsError)` at runtime.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ windows-core = { version = ">=0.50, <=0.52" }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 js-sys = "0.3.66"
+# Set a minimum, but unused, dependency on `log` to ensure that cfg-if 1.0.0
+# gets pulled in in a minimal versions build for the indirect dependency from
+# `wasm-bindgen`.
+log = "0.4.12"
 wasm-bindgen = "0.2.89"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
@@ -40,6 +44,10 @@ iana-time-zone-haiku = { version = "0.1.1", path = "haiku" }
 
 [dev-dependencies]
 chrono-tz = "0.10.1"
+# Set a minimum, but unused, dependency on `getrandom` to ensure that cfg-if
+# 1.0.0 gets pulled in in a minimal versions build for the indirect dependency
+# from `chrono`.
+getrandom = "0.2.1"
 
 [workspace]
 members = [".", "haiku"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,11 @@ js-sys = "0.3.66"
 # Set a minimum, but unused, dependency on `log` to ensure that cfg-if 1.0.0
 # gets pulled in in a minimal versions build for the indirect dependency from
 # `wasm-bindgen`.
-log = "0.4.12"
+log = "0.4.14"
 wasm-bindgen = "0.2.89"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
-wasm-bindgen-test = "0.3"
+wasm-bindgen-test = "0.3.46"
 
 [target.'cfg(target_os = "haiku")'.dependencies]
 iana-time-zone-haiku = { version = "0.1.1", path = "haiku" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ wasm-bindgen = "0.2.89"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 wasm-bindgen-test = "0.3.46"
+getrandom = { version = "0.2.1", features = ["js"] }
 
 [target.'cfg(target_os = "haiku")'.dependencies]
 iana-time-zone-haiku = { version = "0.1.1", path = "haiku" }

--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@
 [![Crate License](https://img.shields.io/crates/l/iana-time-zone.svg)](https://crates.io/crates/iana-time-zone)
 [![build](https://github.com/strawlab/iana-time-zone/actions/workflows/rust.yml/badge.svg)](https://github.com/strawlab/iana-time-zone/actions?query=branch%3Amain)
 
-This small utility crate gets the IANA time zone for the current system.
-This is also known the [tz database](https://en.wikipedia.org/wiki/Tz_database),
-tzdata, the zoneinfo database, and the Olson database.
+This small utility crate gets the IANA time zone for the current system. This is
+also known as the [tz database], tzdata, the zoneinfo database, and the Olson
+database.
+
+[tz database]: https://en.wikipedia.org/wiki/Tz_database
 
 Example:
 
@@ -25,19 +27,21 @@ cargo run --example get_timezone
 
 ## Minimum supported rust version policy
 
-This crate has a minimum supported rust version (MSRV) of 1.48
-for [Tier 1](https://doc.rust-lang.org/1.63.0/rustc/platform-support.html) platforms.
+This crate has a minimum supported rust version (MSRV) of 1.61.0 for [Tier 1]
+platforms.
 
-Updates to the MSRV are sometimes necessary due to the MSRV of dependencies. MSRV updates will
-not be indicated as a breaking change to the semver version.
+[tier 1]: https://doc.rust-lang.org/1.61.0/rustc/platform-support.html
+
+Updates to the MSRV are sometimes necessary due to the MSRV of dependencies.
+MSRV updates will not be indicated as a breaking change to the semver version.
 
 ## License
 
 Licensed under either of
 
-* Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
   <http://www.apache.org/licenses/LICENSE-2.0>)
-* MIT license ([LICENSE-MIT](LICENSE-MIT) or
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or
   <http://opensource.org/licenses/MIT>)
 
 at your option.

--- a/haiku/Cargo.toml
+++ b/haiku/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["IANA", "time"]
 categories = ["date-and-time", "internationalization", "os"]
 readme = "README.md"
 edition = "2018"
+rust-version = "1.61.0"
 
 [dependencies]
 


### PR DESCRIPTION
[Rust 1.61.0 came out in May 2022](https://blog.rust-lang.org/2022/05/19/Rust-1.61.0.html). CI is quite red, largely due to dep resolution, parsing, and compilation failures on the 1.48.0 toolchain.

Given our major reverse dep has increased MSRV, I feel we can do the same to ease the CI burden.

There are _a lot_ of CI jobs here and I haven't looked at all of them. @astraw, @Kijewski I could use your help determining if there is cruft here we can get rid of.

Additionally, on macOS, it looks like GitHub is moving in the direction of arm64 runners, which don't have a Rust toolchain in 1.48. Even in 1.61, the `aarch64-apple-darwin` target is only tier 2.