### PR TITLE
Upgrade to 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["IANA", "time"]
 categories = ["date-and-time", "internationalization", "os"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 rust-version = "1.61.0"
 
 [features]

--- a/haiku/Cargo.toml
+++ b/haiku/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["IANA", "time"]
 categories = ["date-and-time", "internationalization", "os"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 rust-version = "1.61.0"
 
 [dependencies]

--- a/src/tz_aix.rs
+++ b/src/tz_aix.rs
@@ -1,6 +1,6 @@
+use std::env;
 use std::fs::OpenOptions;
 use std::io::{BufRead, BufReader};
-use std::env;
 
 pub(crate) fn get_timezone_inner() -> Result<String, crate::GetTimezoneError> {
     env::var("TZ").map_err(|_| crate::GetTimezoneError::OsError)


### PR DESCRIPTION
Since MSRV is now 1.61.0, we can compile with 2021 edition.

I followed the steps here:

- https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html

I consider this low risk, but I don't think we compile all the platforms we support in CI.