### PR TITLE
Add support for VxWorks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ mod ffi_utils;
 #[cfg_attr(target_os = "aix", path = "tz_aix.rs")]
 #[cfg_attr(target_os = "android", path = "tz_android.rs")]
 #[cfg_attr(target_os = "haiku", path = "tz_haiku.rs")]
+#[cfg_attr(target_os = "vxworks", path = "tz_vxworks.rs")]
 mod platform;
 
 /// Error types

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -5,5 +5,6 @@ pub fn get_timezone_inner() -> Result<String, crate::GetTimezoneError> {
 #[cfg(not(feature = "fallback"))]
 compile_error!(
     "iana-time-zone is currently implemented for Linux, Window, MacOS, FreeBSD, NetBSD, \
-    OpenBSD, Dragonfly, WebAssembly (browser), iOS, Illumos, Android, AIX, Solaris and Haiku.",
+    OpenBSD, Dragonfly, WebAssembly (browser), iOS, Illumos, Android, AIX, Solaris, VxWorks \
+    and Haiku.",
 );

--- a/src/tz_vxworks.rs
+++ b/src/tz_vxworks.rs
@@ -1,0 +1,29 @@
+use std::io::{Error, ErrorKind};
+use vxal::timezone::{get_default_timezone, get_filepaths};
+use std::fs::read_to_string;
+
+pub(crate) fn get_timezone_inner() -> Result<String, crate::GetTimezoneError> {
+    read_timezone()
+        .or_else(|_| Ok(get_default_timezone().to_string()))
+}
+
+fn read_timezone() -> Result<String, crate::GetTimezoneError> {
+    for path in get_filepaths() {
+        let contents = read_to_string(path);
+        if contents.is_ok() {
+            let mut contents = contents.unwrap();
+
+            // Trim to the correct length without allocating.
+            contents.truncate(contents.trim_end().len());
+
+            // Skip blank file
+            if contents.len() < 1 {
+                continue;
+            }
+
+            return Ok(contents);
+        }
+    }
+
+    Err(crate::GetTimezoneError::IoError(Error::from(ErrorKind::NotFound)))
+}


### PR DESCRIPTION
This adds support for VxWorks in iana-time-zone. The added functionality is basically just a wrapper around VXAL crate where the actual implementation lives. VXAL is an internal crate which is automatically added to the rustc invocation by our custom rustc wrapper. Hence, there is no need to add anything to the toml file.

Please let me know if there are any concerns.