### PR TITLE
Bump the `windows-core` version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ android_system_properties = "0.1.5"
 core-foundation-sys = "0.8.6"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-core = ">=0.56, <=0.61"
+windows-core = ">=0.56, <=0.62"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 js-sys = "0.3.66"


### PR DESCRIPTION
This closes #176. The crate still compiles fine and all tests still pass.