### PR TITLE
Add s390x target to Rust CI workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -113,6 +113,7 @@ jobs:
       fail-fast: false
       matrix:
         target:
+          - s390x-unknown-linux-gnu
           - x86_64-unknown-freebsd
           - x86_64-unknown-illumos
           # # NetBSD disabled waiting for release with fix from


### PR DESCRIPTION
Adding big-endian linux to CI to ensure it is supported