### PR TITLE
chore: fix the incorrect logo URL

### DIFF
--- a/haiku/src/lib.rs
+++ b/haiku/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! [![Crates.io](https://img.shields.io/crates/v/iana-time-zone-haiku.svg)](https://crates.io/crates/iana-time-zone-haiku)
 //! [![Documentation](https://docs.rs/iana-time-zone/badge.svg)](https://docs.rs/iana-time-zone/)
-//! [![Crate License](https://img.shields.io/crates/l/iana-time-zone-haiku-haiku.svg)](https://crates.io/crates/iana-time-zone-haiku)
+//! [![Crate License](https://img.shields.io/crates/l/iana-time-zone-haiku.svg)](https://crates.io/crates/iana-time-zone-haiku)
 //! [![build](https://github.com/strawlab/iana-time-zone/workflows/build/badge.svg?branch=main)](https://github.com/strawlab/iana-time-zone/actions?query=branch%3Amain)
 //!
 //! [iana-time-zone](https://github.com/strawlab/iana-time-zone) support crate for Haiku OS.


### PR DESCRIPTION
Old url is wrong
<img width="552" height="102" alt="image" src="https://github.com/user-attachments/assets/54cf2534-5a14-4e8b-9eed-63ff0256c8f8" />

Use the correct one

<img width="595" height="134" alt="image" src="https://github.com/user-attachments/assets/33b863fe-cc27-4e5c-97f2-ec89589a10f4" />
